### PR TITLE
Put a space between candidate and annotation

### DIFF
--- a/company-cabal.el
+++ b/company-cabal.el
@@ -151,8 +151,8 @@ Post completion is disabled if it is nil."
   (let ((type (get-text-property 0 :type candidate))
         (ver (get-text-property 0 :version candidate)))
     (cond
-     (type (symbol-name type))
-     (ver ver))))
+     (type (concat " "(symbol-name type)))
+     (ver  (concat " " ver)))))
 
 (defun company-cabal-post-completion (candidate)
   "Append something or modify it after completion according to CANDIDATE.


### PR DESCRIPTION
A screenshot is worth a thousand words:

![screenshot](https://cloud.githubusercontent.com/assets/373460/11843311/46a4f620-a409-11e5-9373-4d3ae325df34.gif)

If you prefer `(format " %s" ...)` to `(concat " " ...)`, I can change it.
